### PR TITLE
Input_arguments allows for multiple defaults

### DIFF
--- a/format_dictionary.yaml
+++ b/format_dictionary.yaml
@@ -28,8 +28,8 @@ format_version: 1.0
     argument_name: (Empty, Variable) 
       description: Description of the argument
         type: (Path | String | URL)
-        defaults: (Optional) Default values of the argument derived from CTI.
-          - List of values.
+        defaults: (Optional) Default values of the argument.
+          - List of possible values derived from CTI.
 
   dependency_executor_name: (Optional) Name of the executor used to execute the prerequisite command
   dependencies:


### PR DESCRIPTION
Made input_argument's default field into a list that can contain multiple elements. This way, users of the YAML can pick from several CTI-derived variants or values when building the final procedure.