### PR TITLE
Update JSON Schema

### DIFF
--- a/resources/format_schema.json
+++ b/resources/format_schema.json
@@ -10,18 +10,35 @@
     "anyOf": [
       {
         "type": "object",
-        "title": "Version Metadata",
-        "description": "Captures Metadata about the ATT&CK Version and Format Schema (this document).",
+        "title": "Emulation Plan Details",
+        "description": "Captures Metadata about this Plan, ATT&CK Version and Format Schema (this document).",
         "additionalProperties": false,
         "properties": {
-          "version": {
+          "emulation_plan_details": {
             "type": "object",
             "additionalProperties": false,
             "required": [
+              "id",
+              "adversary_name",
+              "adversary_description",
               "attack_version",
               "format_version"
             ],
             "properties": {
+              "id": {
+                "type": "string",
+                "description": "GUID for the Emulation Plan. (RFC 4122)",
+                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+                "examples": [
+                  "e44a39ce-0651-4ddd-8f05-f83aa2ffd657"
+                ]
+              },
+              "adversary_name": {
+                "type": "string"
+              },
+              "adversary_description": {
+                "type": "string"
+              },
               "attack_version": {
                 "type": "number"
               },

--- a/resources/format_schema.json
+++ b/resources/format_schema.json
@@ -133,10 +133,20 @@
                     ],
                     "properties": {
                       "command": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The command to be executed for this step."
                       },
                       "payloads": {
-                        "type": "string"
+                        "type": "array",
+                        "description": "All payloads used for this step.",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "cleanup": {
+                        "type": "string",
+                        "description": "A cleanup command that runs after the command in this step."
                       }
                     }
                   }


### PR DESCRIPTION
Applies the following changes to the JSON Schema:

- Plan Metadata
  - `version` renamed to `emulation_plan_details`
  - New fields `id`, `adversary_name`, `adversary_description` (all required)

- Procedures
  - `payloads` now defined as array
  - New field `cleanup` (optional)

closes #22 