### PR TITLE
add a script to convert Adversary Emulation Plan to MITRE CALDERA plugin

### DIFF
--- a/resources/ctid_aep_to_caldera.py
+++ b/resources/ctid_aep_to_caldera.py
@@ -1,0 +1,138 @@
+import sys
+import yaml
+from pathlib import Path
+
+"""
+Convert CTID Adversary Emulation Plan's YAML to MITRE CALDERA Plugin.
+
+Prepare:
+1. Save this script
+2. Clone the CTID "adversary_emulation_library" repository
+    $ git clone git@github.com:center-for-threat-informed-defense/adversary_emulation_library.git
+3. Clone the MITRE CALDERA version 2.8.0 repository and setup it
+    $ git clone https://github.com/mitre/caldera.git --recursive --branch 2.8.0 
+    $ cd caldera
+    $ sudo apt install -y python3-pip
+    $ pip3 install -r requirements.txt
+
+How to convert:
+1. Open a command shell terminal 
+2. Execute this script, for example to convert FIN6 emulation plan:
+    $ python3 ctid_aep_to_caldera.py "[ctid_directory]'/fin6/Emulation_Plan/FIN6.yaml "[caldera_directory]"/plugins/ctid_fin6
+   (The last argument specifies where plugins are stored, and the directory name becomes your caldera plugin name.)
+
+How to enable the MITRE CALDERA Plugin:
+1. Start the MITRE CALDERA server
+    $ cd "[caldera_directory]"
+    $ python3 server.py --insecure
+2. Login to the MITRE CALDERA as a red team using a Google Chrome browser
+    URL: http://localhost:8888/
+    username: red
+    password: admin
+3. Move your mouse cursor on "navigate" menu and click "configuration" in "Advanced"
+4. Click the "enable" button on the right of your plugin name in "Plugins"
+5. Restart the MITRE CALDERA Server
+
+How to edit abilities:
+1. Login to the MITRE CALDERA as a red team using a Google Chrome browser
+2. Move your mouse cursor on "navigate" menu and click "adversaries" in "Campaigns"
+3. Select a emulation plan name in the "Select an existing profile" pull-down menu
+4. Drag and drop abilities to change their order
+5. Click The "?" button on the upper right of each ability to edit details
+
+"""
+
+__license__ = "Apache License 2.0"
+__copyright__ = "FUJITSU SYSTEM INTEGRATION LABORATORIES LTD."
+__author__ = "Kazuhisa SHIRAKAMI"
+__author_email__ = "k.shirakami@fujitsu.com"
+__status__ = "prototype"
+__version__ = "1.0.0"
+__date__ = "02 September 2020"
+
+
+class AdversaryEmulationPlan:
+
+    def __init__(self, yaml_path):
+        with open(yaml_path, encoding='utf-8') as f:
+            first_item, *abilities = yaml.safe_load(f)
+        emulation_plan_details = first_item['emulation_plan_details']
+        self.id = emulation_plan_details['id']
+        self.name = emulation_plan_details['adversary_name']
+        self.description = emulation_plan_details['adversary_description']
+        self.abilities = abilities
+
+
+class CalderaPlugin:
+
+    def __init__(self, path):
+        path = Path(path)
+        self.path = path.parent / path.name.replace(' ', '_').lower()
+        self.script_path = self.path / 'hook.py'
+
+    def adversary_path(self, adversary):
+        return self.path / 'data' / 'adversaries' / f'{adversary.id}.yml'
+
+    def ability_path(self, ability):
+        path = self.path / 'data' / 'abilities'
+        if 'tactic' in ability:
+            path /= ability['tactic']
+        path /= f'{ability["id"]}.yml'
+        return path
+
+    def script_template(self, adversary):
+        return f"""\
+from app.utility.base_world import BaseWorld
+
+name = '{adversary.name}'
+description = '{adversary.description}'
+address = None
+access = BaseWorld.Access.RED
+
+
+async def enable(services):
+    pass
+"""
+
+    def save_adversary(self, adversary):
+        profile = {
+            'id': adversary.id,
+            'name': adversary.name,
+            'description': adversary.description,
+            'atomic_ordering': [ability['id'] for ability in adversary.abilities]
+        }
+        path = self.adversary_path(adversary)
+        path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            yaml.dump(profile, stream=f)
+
+    def save_ability(self, ability):
+        path = self.ability_path(ability)
+        path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            yaml.dump([ability], stream=f)
+
+    def save_script(self, adversary):
+        path = self.script_path
+        path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(self.script_template(adversary))
+
+
+def convert(ctid_yaml_path, plugin_path):
+    adversary = AdversaryEmulationPlan(ctid_yaml_path)
+    caldera_plugin = CalderaPlugin(plugin_path)
+    caldera_plugin.save_adversary(adversary)
+    for ability in adversary.abilities:
+        caldera_plugin.save_ability(ability)
+    caldera_plugin.save_script(adversary)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage:", sys.argv[0], "<ctid_yaml_path>", "<plugin_path>")
+        exit(1)
+    convert(ctid_yaml_path=sys.argv[1], plugin_path=sys.argv[2])
+
+if __name__ == '__main__':
+    main()

--- a/resources/ctid_aep_to_caldera.py
+++ b/resources/ctid_aep_to_caldera.py
@@ -47,8 +47,8 @@ __copyright__ = "FUJITSU SYSTEM INTEGRATION LABORATORIES LTD."
 __author__ = "Kazuhisa SHIRAKAMI"
 __author_email__ = "k.shirakami@fujitsu.com"
 __status__ = "prototype"
-__version__ = "1.0.0"
-__date__ = "02 September 2020"
+__version__ = "1.0.1"
+__date__ = "06 September 2020"
 
 
 class AdversaryEmulationPlan:
@@ -104,13 +104,13 @@ async def enable(services):
         path = self.adversary_path(adversary)
         path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
         with open(path, 'w', encoding='utf-8') as f:
-            yaml.dump(profile, stream=f)
+            yaml.dump(profile, stream=f, sort_keys=False)
 
     def save_ability(self, ability):
         path = self.ability_path(ability)
         path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
         with open(path, 'w', encoding='utf-8') as f:
-            yaml.dump([ability], stream=f)
+            yaml.dump([ability], stream=f, sort_keys=False)
 
     def save_script(self, adversary):
         path = self.script_path


### PR DESCRIPTION
I have created a script to convert CTID Adversary Emulation Plan's yaml to MITRE CALDERA plugin.
Unfortunately, running the adversary emulation plan on MITRE CALDERA's operations causes command to exit with an error.
If that's OK, please pull this.