### PR TITLE
Correct adversary_name in APT29 yaml

### DIFF
--- a/apt29/Emulation_Plan/APT29.yaml
+++ b/apt29/Emulation_Plan/APT29.yaml
@@ -2,7 +2,7 @@
 
 - emulation_plan_details:
     id: 4975696e-1d41-11eb-adc1-0242ac120002
-    adversary_name: APT29 Adversary Emulation Plan
+    adversary_name: APT29
     adversary_description: APT29 is a threat group that has been attributed to the Russian government who have been in operation since at least 2008. This group reportedly compromised the Democratic National Committee starting in the summer of 2015.
     attack_version: 8.1
     format_version: 1.0


### PR DESCRIPTION
Corrected "adversary_name" to reflect name of adversary and not the plan .