### PR TITLE
Fix xfreerdp change of syntax in T1021.001

### DIFF
--- a/oilrig/Emulation_Plan/yaml/oilrig.yaml
+++ b/oilrig/Emulation_Plan/yaml/oilrig.yaml
@@ -593,7 +593,7 @@
     linux:
       proc:
         command: |
-          exec-background xfreerdp /u:'#{network.domain.name}\#{initial.target.user}' /p:'#{initial.target.password}' /v:localhost:13389 /cert-ignore
+          exec-background xfreerdp /u:'#{network.domain.name}\#{initial.target.user}' /p:'#{initial.target.password}' /v:localhost:13389 /cert:ignore
 
 
 # Step 8


### PR DESCRIPTION
A typo, the correct syntax is /cert:ignore